### PR TITLE
[20190131] circleciのセットアップ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,52 @@
+version: 2
+jobs:
+  build:
+    working_directory: /go/src/github.com/teixy/
+
+    docker:
+      - image: circleci/golang:1.10
+    
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+              - v1-vendor-{{ .Branch }}-{{ checksum "src/Gopkg.lock" }}
+              - v1-vendor-{{ .Branch }}
+              - v1-vendor
+              - v1-dep
+
+      - run:
+          name: dep ensure
+          command: |
+              cd go/
+              if [ ! -d vendor ]; then
+                if ! type dep >/dev/null 2>&1; then
+                  go get -u github.com/golang/dep/cmd/dep
+                fi
+                dep ensure
+              fi
+      # ローカルとcircleci上でgo getしたdepのversionが異なると
+      # dep ensureしたときにGopkg.lockのchecksumが変わってしまい
+      # 別のcacheとして保存されてしまいrestore_cacheで取り出せない
+      # cacheしてるdepのversionはv0.5.0
+      - save_cache:
+          key: v1-vendor-{{ .Branch }}-{{ checksum "go/Gopkg.lock" }}
+          paths:
+              - go/vendor
+
+      - save_cache:
+          key: v1-dep
+          paths:
+              - /go/bin/dep
+
+      - run:
+          name: go build
+          command: |
+              go build -v -o go/main go/main.go
+
+workflows:
+    version: 2
+    build:
+      jobs:
+        - build


### PR DESCRIPTION
# [20190131] circleciのセットアップ

## 概要
- とりあえずgoのビルドだけ設定に書いておく
- go testの設定は今後
- vueのビルドもここでやりたい

[Packing A Config](https://circleci.com/docs/ja/2.0/local-cli/#packing-a-config)
複数のconfigファイルをまとめるコマンドがあるので、今後設定が増えてくると便利かもしれない

## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



