### PR TITLE
[20190131] circleci configファイルでパスが間違っていたので修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
       - restore_cache:
           keys:
-              - v1-vendor-{{ .Branch }}-{{ checksum "src/Gopkg.lock" }}
+              - v1-vendor-{{ .Branch }}-{{ checksum "go/Gopkg.lock" }}
               - v1-vendor-{{ .Branch }}
               - v1-vendor
               - v1-dep


### PR DESCRIPTION
# [20190131] circleci configファイルでパスが間違っていたので修正

## 概要
- vendorをキャッシュするのに得る、`Gopkc.lock`のチェックサムを出すときの`Gopkg.lock`のパスが間違っていたので修正


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



