### PR TITLE
[20190209] AWS cloud9 が動いているamazon linuxのtimezoneの設定をJSTに変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,12 @@ $ yum install tig
 ```
 で入るはず  
 gitのコミット履歴を見やすくしてくれる
+
+## AWS Cloud9の環境設定
+
+### timezone
+デフォルトではUTCなので変更する　　
+```
+% cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+```
+


### PR DESCRIPTION
# [20190209] AWS cloud9 が動いているamazon linuxのtimezoneの設定をJSTに変更する

## 概要
 - READMEにコマンドを追記
- datetimectlはamazon linux2からなので使えない


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



