### PR TITLE
[20190210] db/migrate.go内の変数名の意味が違ってきたので修正

### DIFF
--- a/db/migrate.go
+++ b/db/migrate.go
@@ -11,7 +11,7 @@ import (
 //declare command line options
 var (
 	command = flag.String("exec", "", "set up or down as a argument")
-	fix     = flag.Bool("f", false, "force exec fixed sql")
+	force   = flag.Bool("f", false, "force exec fixed sql")
 )
 
 //available command list
@@ -51,8 +51,8 @@ func main() {
 
 	fmt.Println("command: exec", *command)
 	if *command == "up" {
-		if dirty && *fix {
-			fmt.Println("fix=true: force execute current version sql")
+		if dirty && *force {
+			fmt.Println("force=true: force execute current version sql")
 			m.Force(int(version))
 		}
 		err := m.Up()
@@ -64,8 +64,8 @@ func main() {
 	}
 
 	if *command == "down" {
-		if dirty && *fix {
-			fmt.Println("fix=true: force execute current version sql")
+		if dirty && *force {
+			fmt.Println("force=true: force execute current version sql")
 			m.Force(int(version))
 		}
 		err := m.Down()

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -82,8 +82,8 @@ func showUsageMessge() {
 	fmt.Println("Usage")
 	fmt.Println("  go run migrate.go -exec <command>\n")
 	fmt.Println("Available Exec Commands: ")
-	for command, detail := range available_exec_commands {
-		fmt.Println("  " + command + " : " + detail)
+	for available_command, detail := range available_exec_commands {
+		fmt.Println("  " + available_command + " : " + detail)
 	}
 	fmt.Println("-------------------------------------")
 }

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"os"
 )
 
 //declare command line options
@@ -27,11 +28,13 @@ func main() {
 	if len(*command) < 1 {
 		fmt.Println("\nerror: no argument\n")
 		showUsageMessge()
+		os.Exit(1)
 		return
 	}
 	if len(available_exec_commands[*command]) < 1 {
 		fmt.Println("\nerror: invalid command '" + *command + "'\n")
 		showUsageMessge()
+		os.Exit(1)
 		return
 	}
 
@@ -58,6 +61,7 @@ func main() {
 		err := m.Up()
 		if err != nil {
 			fmt.Println("err", err)
+			os.Exit(1)
 		} else {
 			fmt.Println("command success:", *command)
 		}
@@ -71,6 +75,7 @@ func main() {
 		err := m.Down()
 		if err != nil {
 			fmt.Println("err", err)
+			os.Exit(1)
 		} else {
 			fmt.Println("command success:", *command)
 		}


### PR DESCRIPTION
# [20190210] db/migrate.go内の変数名の意味が違ってきたので修正

## 概要
- fixをforceにする
- commandをavailable_commandにする

その他
- errのときはexit(1)を返す


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



