### PR TITLE
[20190210] migrate.goのリファクタリング：switchを使うように変更

### DIFF
--- a/db/migrate.go
+++ b/db/migrate.go
@@ -50,11 +50,7 @@ func main() {
 	}
 
 	version, dirty, err := m.Version()
-	fmt.Println("-------------------")
-	fmt.Println("version  : ", version)
-	fmt.Println("dirty    : ", dirty)
-	fmt.Println("error    : ", err)
-	fmt.Println("-------------------")
+	showVersionInfo(version, dirty, err)
 
 	fmt.Println("command: exec", *command)
 	if *command == "up" {
@@ -95,4 +91,12 @@ func showUsageMessge() {
 		fmt.Println("  " + available_command + " : " + detail)
 	}
 	fmt.Println("-------------------------------------")
+}
+
+func showVersionInfo(version uint, dirty bool, err error) {
+	fmt.Println("-------------------")
+	fmt.Println("version  : ", version)
+	fmt.Println("dirty    : ", dirty)
+	fmt.Println("error    : ", err)
+	fmt.Println("-------------------")
 }

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -37,12 +37,6 @@ func main() {
 		os.Exit(1)
 		return
 	}
-	if len(available_exec_commands[*command]) < 1 {
-		fmt.Println("\nerror: invalid command '" + *command + "'\n")
-		showUsageMessge()
-		os.Exit(1)
-		return
-	}
 
 	m, err := migrate.New(source, database)
 	if err != nil {

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -9,6 +9,12 @@ import (
 	"os"
 )
 
+//sql and database info
+const (
+	source   = "file://./sql/"
+	database = "mysql://teixy:teixy@tcp(0.0.0.0:3306)/teixy_article"
+)
+
 //declare command line options
 var (
 	command = flag.String("exec", "", "set up or down as a argument")
@@ -38,9 +44,7 @@ func main() {
 		return
 	}
 
-	m, err := migrate.New(
-		"file://./sql/",
-		"mysql://teixy:teixy@tcp(0.0.0.0:3306)/teixy_article")
+	m, err := migrate.New(source, database)
 	if err != nil {
 		fmt.Println("err", err)
 	}

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -60,6 +60,8 @@ func main() {
 	}
 }
 
+//exec up sqls
+//with force option if needed
 func upSql(m *migrate.Migrate, version uint, dirty bool) {
 	if dirty && *force {
 		fmt.Println("force=true: force execute current version sql")
@@ -70,10 +72,15 @@ func upSql(m *migrate.Migrate, version uint, dirty bool) {
 		fmt.Println("err", err)
 		os.Exit(1)
 	} else {
-		fmt.Println("command success:", *command)
+		fmt.Println("success:", *command+"\n")
+		fmt.Println("updated version info")
+		version, dirty, err := m.Version()
+		showVersionInfo(version, dirty, err)
 	}
 }
 
+//exec up sqls
+//with force option if needed
 func downSql(m *migrate.Migrate, version uint, dirty bool) {
 	if dirty && *force {
 		fmt.Println("force=true: force execute current version sql")
@@ -84,9 +91,11 @@ func downSql(m *migrate.Migrate, version uint, dirty bool) {
 		fmt.Println("err", err)
 		os.Exit(1)
 	} else {
-		fmt.Println("command success:", *command)
+		fmt.Println("success:", *command+"\n")
+		fmt.Println("updated version info")
+		version, dirty, err := m.Version()
+		showVersionInfo(version, dirty, err)
 	}
-
 }
 
 func showUsageMessge() {

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -48,38 +48,51 @@ func main() {
 	if err != nil {
 		fmt.Println("err", err)
 	}
-
 	version, dirty, err := m.Version()
 	showVersionInfo(version, dirty, err)
 
 	fmt.Println("command: exec", *command)
-	if *command == "up" {
-		if dirty && *force {
-			fmt.Println("force=true: force execute current version sql")
-			m.Force(int(version))
-		}
-		err := m.Up()
-		if err != nil {
-			fmt.Println("err", err)
-			os.Exit(1)
-		} else {
-			fmt.Println("command success:", *command)
-		}
+	switch *command {
+	case "up":
+		upSql(m, version, dirty)
+	case "down":
+		downSql(m, version, dirty)
+	case "version":
+		//do nothing
+	default:
+		fmt.Println("\nerror: invalid command '" + *command + "'\n")
+		showUsageMessge()
+		os.Exit(1)
+	}
+}
+
+func upSql(m *migrate.Migrate, version uint, dirty bool) {
+	if dirty && *force {
+		fmt.Println("force=true: force execute current version sql")
+		m.Force(int(version))
+	}
+	err := m.Up()
+	if err != nil {
+		fmt.Println("err", err)
+		os.Exit(1)
+	} else {
+		fmt.Println("command success:", *command)
+	}
+}
+
+func downSql(m *migrate.Migrate, version uint, dirty bool) {
+	if dirty && *force {
+		fmt.Println("force=true: force execute current version sql")
+		m.Force(int(version))
+	}
+	err := m.Down()
+	if err != nil {
+		fmt.Println("err", err)
+		os.Exit(1)
+	} else {
+		fmt.Println("command success:", *command)
 	}
 
-	if *command == "down" {
-		if dirty && *force {
-			fmt.Println("force=true: force execute current version sql")
-			m.Force(int(version))
-		}
-		err := m.Down()
-		if err != nil {
-			fmt.Println("err", err)
-			os.Exit(1)
-		} else {
-			fmt.Println("command success:", *command)
-		}
-	}
 }
 
 func showUsageMessge() {


### PR DESCRIPTION
# [20190210] migrate.goのリファクタリング：switchを使うように変更

## 概要
- switch文を使うように変更
- コメントを加える


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



