### PR TITLE
[20190217] articleのupdate apiの実装

### DIFF
--- a/go/controllers/update_articles.go
+++ b/go/controllers/update_articles.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Status struct {
-	Status int `validate:"required,min=1,numeric"`
+	Status int `validate:"min=0,max=1,numeric"`
 }
 
 type Params struct {

--- a/go/controllers/update_articles.go
+++ b/go/controllers/update_articles.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/teixy/go/models"
+	"gopkg.in/go-playground/validator.v9"
+	"net/http"
+	"strconv"
+)
+
+type Status struct {
+	Status int `validate:"required,min=1,numeric"`
+}
+
+type Params struct {
+	Id
+	Article
+	Status
+}
+
+func UpdateArticle(c echo.Context) error {
+	article_id, _ := strconv.Atoi(c.Param("id"))
+	max_score, _ := strconv.Atoi(c.FormValue("max_score"))
+	min_score, _ := strconv.Atoi(c.FormValue("min_score"))
+	status, _ := strconv.Atoi(c.FormValue("status")) 
+	params := Params{
+		Id{article_id},
+		Article{
+			min_score,
+			max_score,
+			c.FormValue("title"),
+			c.FormValue("punch_line"),
+			c.FormValue("content"),
+		},
+		Status{status},
+	}
+
+	validate = validator.New()
+	err := validate.Struct(params)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	result, err := models.UpdateArticle(
+		params.Id.Id,
+		params.Min_Score,
+		params.Max_Score,
+		params.Title,
+		params.Punch_Line,
+		params.Content,
+		params.Status.Status,
+	)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	update_id, _ := result.LastInsertId()
+	rows, _ := result.RowsAffected()
+	query_result := QueryResult{update_id, rows}
+
+	return c.JSON(http.StatusCreated, query_result)
+}

--- a/go/main.go
+++ b/go/main.go
@@ -27,5 +27,7 @@ func main() {
 
 	e.POST("/articles", controllers.CreateArticle)
 
+	e.PUT("/articles/:id", controllers.UpdateArticle)
+
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/go/models/articles.go
+++ b/go/models/articles.go
@@ -84,3 +84,34 @@ func CreateArticle(min_score int, max_score int, title string, punch_line string
 		StatusOff,
 	)
 }
+
+func UpdateArticle(id int, min_score int, max_score int, title string, punch_line string, content string, status int) (sql.Result, error) {
+
+	data := db.CreateConectionTeixyArticles()
+
+	stmt, err := data.Prepare(`
+	UPDATE articles SET
+		min_score = ?,
+		max_score = ?,
+		title = ?,
+		punch_line = ?,
+		content = ?,
+		status = ?
+	WHERE id = ?
+	`)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer stmt.Close()
+	return stmt.Exec(
+		min_score,
+		max_score,
+		title,
+		punch_line,
+		content,
+		status,
+		id,
+	)
+}


### PR DESCRIPTION
# [20190217] articleのupdate apiの実装

## 概要
- idを指定して、articleの内容をupdateする
- httpのメソッドはPUT


## タスクリスト

- [ ] 
- [ ] 
- [ ] 

## その他



